### PR TITLE
Added color for linkComplex, pretty-link and timeline-link

### DIFF
--- a/sass/_twitter-night-mode.scss
+++ b/sass/_twitter-night-mode.scss
@@ -384,7 +384,11 @@ body.three-col.logged-in {
 .header-cell.date-column,
 .header-cell.ip-column,
 .view-toggler .active,
-.Icon--device {
+.Icon--device,
+.u-linkComplex-target,
+.pretty-link s,
+.pretty-link b,
+.twitter-timeline-link {
 	color: $white!important;
 }
 


### PR DESCRIPTION
Tweet before
<img width="624" alt="screen shot 2016-09-22 at 12 17 07 am" src="https://cloud.githubusercontent.com/assets/1863771/18724481/2f01f17a-805a-11e6-81b4-69f430c597c7.png">
Tweet after
<img width="638" alt="screen shot 2016-09-22 at 12 18 04 am" src="https://cloud.githubusercontent.com/assets/1863771/18724484/2f162578-805a-11e6-9a1a-a29770b550e2.png">
Trends before
<img width="304" alt="screen shot 2016-09-22 at 12 18 23 am" src="https://cloud.githubusercontent.com/assets/1863771/18724482/2f0edb24-805a-11e6-8ad3-38da599411c9.png">
Trends after
<img width="300" alt="screen shot 2016-09-22 at 12 18 45 am" src="https://cloud.githubusercontent.com/assets/1863771/18724483/2f14f19e-805a-11e6-95fd-fc9624f9593e.png">
