### PR TITLE
Changes dark grey text to a lighter color for better readability

### DIFF
--- a/sass/_twitter-night-mode.scss
+++ b/sass/_twitter-night-mode.scss
@@ -29,7 +29,7 @@ body.three-col.logged-in {
 	}
 
 	.QuoteTweet-fullname {
-		color: $tweet-name-color!important;
+		color: $tweet-name-color;
 	}
 
 	.QuoteTweet-text {
@@ -441,7 +441,7 @@ body.three-col.logged-out {
 	padding: 3px;
 	color: lighten($text-grey, 7%)!important;
 }
-.twitter-atreply, .js-display-url, .twitter-hashtag {
+.twitter-atreply, .twitter-timeline-link, .twitter-hashtag {
 	color: $text-grey!important;
 }
 
@@ -450,7 +450,7 @@ body.three-col.logged-out {
 }
 
 .QuoteTweet-fullname.u-linkComplex-target {
-	color: $white!important;
+	color: $white;
 }
 
 .QuoteTweet-text .pretty-link b, .QuoteTweet-text .pretty-link s {
@@ -458,7 +458,7 @@ body.three-col.logged-out {
 }
 
 // Change trends window
-.js-location-nonpersonalized {
+.trends-current-location {
 	color: $text-grey!important;	
 }
 

--- a/sass/_twitter-night-mode.scss
+++ b/sass/_twitter-night-mode.scss
@@ -29,7 +29,7 @@ body.three-col.logged-in {
 	}
 
 	.QuoteTweet-fullname {
-		color: $quote-tweet-fullname-color;
+		color: $tweet-name-color!important;
 	}
 
 	.QuoteTweet-text {
@@ -192,6 +192,10 @@ body.three-col.logged-in {
 	.Footer-link {
 		color: $link-color!important;
 	}
+}
+
+.ProfileCard-bio, .ProfileCard-locationAndUrl {
+	color: $text-grey!important;
 }
 
 // notifications tab
@@ -437,6 +441,24 @@ body.three-col.logged-out {
 	padding: 3px;
 	color: lighten($text-grey, 7%)!important;
 }
-.twitter-atreply, .js-display-url{
+.twitter-atreply, .js-display-url, .twitter-hashtag {
 	color: $text-grey!important;
 }
+
+.MomentFormatLink-title, .MomentFormatLink-description {
+	color: $text-grey!important;
+}
+
+.QuoteTweet-fullname.u-linkComplex-target {
+	color: $white!important;
+}
+
+.QuoteTweet-text .pretty-link b, .QuoteTweet-text .pretty-link s {
+	color: $text-grey!important;
+}
+
+// Change trends window
+.js-location-nonpersonalized {
+		color: $text-grey!important;	
+}
+

--- a/sass/_twitter-night-mode.scss
+++ b/sass/_twitter-night-mode.scss
@@ -459,6 +459,6 @@ body.three-col.logged-out {
 
 // Change trends window
 .js-location-nonpersonalized {
-		color: $text-grey!important;	
+	color: $text-grey!important;	
 }
 


### PR DESCRIPTION
The dark grey text was changed to a light grey or white, which is much more readable against the dark blue background.

Original: http://i.imgur.com/wwzalF4.png
With fix: http://i.imgur.com/r7ptFOZ.png

Mostly impacts the Moments capsule pages. Also changes the bio descriptions when an account is shown in a search result, and a line of text in the "change" trends window.
Fix for #17.
