### PR TITLE
Issue #27 - Fix background resize bug

### DIFF
--- a/sass/_twitter-night-mode.scss
+++ b/sass/_twitter-night-mode.scss
@@ -1,6 +1,7 @@
-body.three-col.logged-in {
+body.logged-in {
 	background-color: $light-bg!important;
 }
+
 * {
 	border-color: $border-color-light !important;
 }


### PR DESCRIPTION
- Removed `.three-col` from the body selector

Three-col is removed when the window shrinks in width.
