### PR TITLE
Changed background-color for trends, search, who to follow, and filters.

### DIFF
--- a/sass/_twitter-night-mode.scss
+++ b/sass/_twitter-night-mode.scss
@@ -490,3 +490,14 @@ body.logged-out {
 .Trends, .WhoToFollow, .AdaptiveRelatedSearches, .SidebarFilterModule, .AdaptiveFiltersBar {
 	background-color: $trends-bg;
 }
+
+// Advanced search page
+.search.advanced-search {
+	background-color: $trends-bg;
+	h1, span {
+		color: $white;
+	}
+	.input-daterange .input-group-addon {
+		background-color: $trends-bg;
+	}
+}

--- a/sass/_twitter-night-mode.scss
+++ b/sass/_twitter-night-mode.scss
@@ -487,3 +487,6 @@ body.logged-out {
 	color: $text-grey!important;	
 }
 
+.Trends, .WhoToFollow, .AdaptiveRelatedSearches, .SidebarFilterModule, .AdaptiveFiltersBar {
+	background-color: $trends-bg;
+}


### PR DESCRIPTION
**before - trends and search**
<img width="907" alt="before_trends_update" src="https://cloud.githubusercontent.com/assets/9044401/24074581/73cafd64-0bd9-11e7-9aa5-daf0c64cbcba.png">

**after - trends and search"
<img width="905" alt="after_trends_update" src="https://cloud.githubusercontent.com/assets/9044401/24074580/73ba66e8-0bd9-11e7-9a78-d92a56059953.png">

