### PR TITLE
change background in Moments' details/headings. 

### DIFF
--- a/sass/_twitter-night-mode.scss
+++ b/sass/_twitter-night-mode.scss
@@ -512,6 +512,10 @@ body.logged-out {
 	color: $white;
 }
 
+.MomentCapsuleSummary-details {
+	background-color: $dark-bg;
+}
+
 .MomentCapsuleSummary-title {
 	color: $white;
 }


### PR DESCRIPTION
Hello. The text in the Moments headings were getting lost on the twitter.com home page. Changing the background in that section should make the text viewable and not have any repercussions outside of that area.